### PR TITLE
Quickfix index out of bounds error

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ type Configs struct {
 	Module            string `env:"module"`
 	Arguments         string `env:"arguments"`
 	CacheLevel        string `env:"cache_level,opt[none,only_deps,all]"`
+	IsDebug           bool   `env:"is_debug,opt[true,false]"`
 }
 
 func failf(f string, args ...interface{}) {
@@ -112,7 +113,7 @@ func filterVariants(module, variant string, variantsMap gradle.Variants) (gradle
 func main() {
 	var config Configs
 
-	if debug := os.Getenv("is_debug"); debug == "yes" {
+	if config.IsDebug {
 		log.SetEnableDebugLog(true)
 		log.Debugf("Debug mode enabled")
 	}

--- a/main.go
+++ b/main.go
@@ -112,6 +112,11 @@ func filterVariants(module, variant string, variantsMap gradle.Variants) (gradle
 func main() {
 	var config Configs
 
+	if debug := os.Getenv("is_debug"); debug == "yes" {
+		log.SetEnableDebugLog(true)
+		log.Debugf("Debug mode enabled")
+	}
+
 	if err := stepconf.Parse(&config); err != nil {
 		failf("Couldn't create step config: %v\n", err)
 	}

--- a/step.yml
+++ b/step.yml
@@ -88,5 +88,5 @@ inputs:
       description: The step will print more verbose logs if enabled.
       is_required: true
       value_options:
-        - "false"
-        - "true"
+      - "false"
+      - "true"

--- a/step.yml
+++ b/step.yml
@@ -80,3 +80,13 @@ inputs:
       - "all"
       - "only_deps"
       - "none"
+  - is_debug: "false"
+    opts: 
+      category: Debug
+      title: "Enable Debug Mode"
+      summary: The step will print more verbose logs if enabled.
+      description: The step will print more verbose logs if enabled.
+      is_required: true
+      value_options:
+        - "false"
+        - "true"

--- a/testaddon.go
+++ b/testaddon.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"github.com/bitrise-io/go-utils/log"
 )
 
 // getUniqueDir returns the unique subdirectory inside the test addon export diroctory for a given artifact.
 func getUniqueDir(path string) (string, error) {
+	log.Debugf("getUniqueDir(%s)", path)
 	parts := strings.Split(path, "/")
 	i := len(parts) - 1
 	for i > 0 && parts[i] != "test-results" {
@@ -38,6 +41,8 @@ func getUniqueDir(path string) (string, error) {
 		return "", fmt.Errorf("get module name: out of index error")
 	}
 	module := parts[i-2]
+	ret := module + "-" + variant
 
-	return module + "-" + variant, nil
+	log.Debugf("getUniqueDir(%s): (%s,%s)", path, ret, nil)
+	return ret, nil
 }

--- a/testaddon.go
+++ b/testaddon.go
@@ -43,6 +43,6 @@ func getUniqueDir(path string) (string, error) {
 	module := parts[i-2]
 	ret := module + "-" + variant
 
-	log.Debugf("getUniqueDir(%s): (%s,%s)", path, ret, nil)
+	log.Debugf("getUniqueDir(%s): (%s,%v)", path, ret, nil)
 	return ret, nil
 }

--- a/testaddon.go
+++ b/testaddon.go
@@ -27,6 +27,10 @@ func getUniqueDir(path string) (string, error) {
 	variant = strings.TrimSuffix(variant, "UnitTest")
 
 	runes := []rune(variant)
+
+	if len(runes) == 0 {
+		return "", fmt.Errorf("get variant name from task name: empty string after trimming")
+	}
 	runes[0] = unicode.ToLower(runes[0])
 	variant = string(runes)
 

--- a/testaddon_test.go
+++ b/testaddon_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetUniqueDir(t *testing.T) {
+	tc := []struct{
+		title string
+		path string
+		wantStr string
+		isErr bool
+	}{
+		{
+			title: "should return error on empty string",
+			path: "",
+			wantStr: "",
+			isErr: true, 
+		},
+		{
+			title: "should return error if artifact path ends in test results folder with trailing slash",
+			path: "/path/to/test-results/",
+			wantStr: "",
+			isErr: true, 
+		},
+	}
+	
+	for _, tt := range tc {
+		str, err := getUniqueDir(tt.path)
+		if str != tt.wantStr || (err != nil) != tt.isErr {
+			t.Fatalf("%s: got (%s, %s)", tt.title, str, err)
+		}
+	}
+
+}


### PR DESCRIPTION
Our assumptions about possible test result path layouts was wrong. Users can have non-Android related tests, whose results will be matched, but cannot be traced back to an Android variant.

Current fix involves logging an error if we're unable to extract a variant name instead of attempting to refine matching pattern.

A proper solution to collect these skipped tests in an "other" folder has been submitted in the meanwhile.