### PR TITLE
Tool-253 collect unmappable test results to other tab

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -43,6 +43,8 @@ workflows:
         - gradlew_path: ./gradlew
     - path::./:
         title: Android Unit Test (monorepo projects in source dir)
+        inputs:
+        - is_debug: "true"
     after-run:
     - check-artifacts
 
@@ -72,6 +74,7 @@ workflows:
         inputs:
         - module: app
         - variant: Debug
+        - is_debug: "true"
     after-run:
     - check-artifacts
 
@@ -95,6 +98,8 @@ workflows:
         - gradlew_path: ./gradlew
     - path::./:
         title: Android Unit Test (android project & mono repo projects in /tmp dir)
+        inputs:
+        - is_debug: "true"
     after-run:
     - check-artifacts
 
@@ -121,6 +126,8 @@ workflows:
         - gradlew_path: ./gradlew
     - path::./:
         title: Android Unit Test (android project with build.gradle.kts)
+        inputs:
+        - is_debug: "true"
     after-run:
     - check-artifacts
     
@@ -195,21 +202,22 @@ workflows:
         inputs:
         - module: app
         - variant: Debug
+        - is_debug: "true"
     - script:
-        title: check exported arftifacts
+        title: check exported artifacts
         is_always_run: true
         inputs:
         - content: |-
             #!/usr/bin/env bash
             set -ex
 
-            # check directory and test-info.json existense
+            # check directory and test-info.json existence
             if [ $(find ${BITRISE_TEST_DEPLOY_DIR} -regex ".*/app-debug/test-info.json" | grep -c .) -eq 0 ]; then
                 echo "ERROR: ${BITRISE_TEST_DEPLOY_DIR} does not contain app-debug/test-info.json."
                 exit 1
             fi
 
-            # check result xml existense
+            # check result xml existence
             if [ ! $(find ${BITRISE_TEST_DEPLOY_DIR} -regex ".*/app-debug/TEST.*.xml" | grep -c .) -eq 2 ]; then
                 echo "ERROR: ${BITRISE_TEST_DEPLOY_DIR} does not contain all test result XMLs."
                 exit 1

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -185,7 +185,7 @@ workflows:
         - is_create_path: true
     - script:
         inputs:
-        - content: git clone -b no-failures $SAMPLE_REPO_GIT_CLONE_URL .
+        - content: git clone -b no-failures $SAMPLE_REPO_GIT_CLONE_URL -b code-coverage .
     - install-missing-android-tools:
         inputs:
         - gradlew_path: ./gradlew

--- a/main.go
+++ b/main.go
@@ -220,8 +220,8 @@ func main() {
 			for _, artifact := range resultXMLs {
 				uniqueDir, err := getVariantDir(artifact.Path)
 				if err != nil {
-					log.Warnf("Failed to export test results for test addon: cannot get export directory for artifact (%s): %s", err)
-					continue
+					uniqueDir = "other"
+					log.Warnf("Could not determine build variant for test output artifact (%s), exporting to 'other' collection", artifact.Path)
 				}
 
 				if err := testaddon.ExportArtifact(artifact.Path, baseDir, uniqueDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -218,13 +218,9 @@ func main() {
 	} else {
 		if baseDir := os.Getenv("BITRISE_TEST_RESULT_DIR"); baseDir != "" {
 			for _, artifact := range resultXMLs {
-				uniqueDir, err := getVariantDir(artifact.Path)
-				if err != nil {
-					uniqueDir = "other"
-					log.Warnf("Could not determine build variant for test output artifact (%s), exporting to 'other' collection", artifact.Path)
-				}
+				dir := getExportDir(artifact.Path)
 
-				if err := testaddon.ExportArtifact(artifact.Path, baseDir, uniqueDir); err != nil {
+				if err := testaddon.ExportArtifact(artifact.Path, baseDir, dir); err != nil {
 					log.Warnf("Failed to export test results for test addon: %s", err)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -18,8 +18,6 @@ import (
 	shellquote "github.com/kballard/go-shellquote"
 )
 
-const resultArtifactPathPattern = "*TEST*.xml"
-
 // Configs ...
 type Configs struct {
 	ProjectLocation      string `env:"project_location,dir"`

--- a/main.go
+++ b/main.go
@@ -135,14 +135,9 @@ func main() {
 	}
 
 	stepconf.Print(config)
-
-	if config.IsDebug {
-		log.SetEnableDebugLog(true)
-		log.Debugf("Debug mode enabled")
-	}
-
-	log.Printf("- Deploy dir: %s", config.DeployDir)
 	fmt.Println()
+
+	log.SetEnableDebugLog(config.IsDebug)
 
 	gradleProject, err := gradle.NewProject(config.ProjectLocation)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func main() {
 	} else {
 		if baseDir := os.Getenv("BITRISE_TEST_RESULT_DIR"); baseDir != "" {
 			for _, artifact := range resultXMLs {
-				uniqueDir, err := getUniqueDir(artifact.Path)
+				uniqueDir, err := getVariantDir(artifact.Path)
 				if err != nil {
 					log.Warnf("Failed to export test results for test addon: cannot get export directory for artifact (%s): %s", err)
 					continue

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func main() {
 		log.Infof("Export XML results for test addon:")
 		fmt.Println()
 
-		exportDirNames := map[string]bool{} // store already used output dir names, to overlapping
+		lastOtherDirIdx := -1
 		xmlResultFilePattern := config.XMLResultDirPattern
 		if !strings.HasSuffix(xmlResultFilePattern, "*.xml") {
 			xmlResultFilePattern += "*.xml"
@@ -236,19 +236,14 @@ func main() {
 			for _, artifact := range resultXMLs {
 				dir := getExportDir(artifact.Path)
 
-				if dir == OtherDirName && exportDirNames[dir] {
+				if dir == OtherDirName {
 					// start indexing other dir name, to avoid overrideing it
 					// e.g.: other, other-1, other-2
-					s := strings.Split(dir, "-")
-					last := s[len(s)-1]
-					idx, err := strconv.Atoi(last)
-					if err != nil {
-						dir = dir + "-1"
-					} else {
-						dir = dir + "-" + strconv.Itoa(idx+1)
+					lastOtherDirIdx++
+					if lastOtherDirIdx > 0 {
+						dir = dir + "-" + strconv.Itoa(lastOtherDirIdx)
 					}
 				}
-				exportDirNames[dir] = true
 
 				if err := testaddon.ExportArtifact(artifact.Path, config.TestResultDir, dir); err != nil {
 					log.Warnf("Failed to export test results for test addon: %s", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+func Test_tryExportTestAddonArtifact(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		artifactPth     string
+		outputDir       string
+		lastOtherDirIdx int
+
+		wantIdx       int
+		wantOutputPth string
+	}{
+		{
+			name:            "Exports Local Unit Test result XML file",
+			artifactPth:     filepath.Join(tmpDir, "./app/build/test-results/testDebugUnitTest/TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml"),
+			outputDir:       filepath.Join(tmpDir, "1"),
+			lastOtherDirIdx: 0,
+			wantIdx:         0,
+			wantOutputPth:   filepath.Join(tmpDir, "1", "app-debug", "TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml"),
+		},
+		{
+			name:            "Exports Jacoco result XML file",
+			artifactPth:     filepath.Join(tmpDir, "./app/build/test-results/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml"),
+			outputDir:       filepath.Join(tmpDir, "2"),
+			lastOtherDirIdx: 0,
+			wantIdx:         1,
+			wantOutputPth:   filepath.Join(tmpDir, "2", "other-1", "jacocoTestReleaseUnitTestReport.xml"),
+		},
+		{
+			name:            "Exports Other XML file",
+			artifactPth:     filepath.Join(tmpDir, "./app/build/test-results/TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml"),
+			outputDir:       filepath.Join(tmpDir, "3"),
+			lastOtherDirIdx: 0,
+			wantIdx:         1,
+			wantOutputPth:   filepath.Join(tmpDir, "3", "other-1", "TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml"),
+		},
+	}
+	for _, tt := range tests {
+		dir := filepath.Dir(tt.artifactPth)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Error(err)
+			continue
+		}
+		if _, err := os.Create(tt.artifactPth); err != nil {
+			t.Error(err)
+			continue
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tryExportTestAddonArtifact(tt.artifactPth, tt.outputDir, tt.lastOtherDirIdx); got != tt.wantIdx {
+				t.Errorf("tryExportTestAddonArtifact() = %v, want %v", got, tt.wantIdx)
+			}
+			if exist, err := pathutil.IsPathExists(tt.wantOutputPth); err != nil {
+				t.Error(err)
+			} else if !exist {
+				t.Errorf("expected output file (%s) does not exist", tt.wantOutputPth)
+			}
+		})
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -53,7 +53,7 @@ inputs:
       summary: Extra arguments passed to the gradle task
       description: Extra arguments passed to the gradle task
       is_required: false
-  - report_path_pattern: "*build/reports/tests/"
+  - report_path_pattern: "*build/reports/tests"
     opts:
       category: Options
       title: Local unit test HTML result directory pattern
@@ -76,7 +76,7 @@ inputs:
 
         to export every variant's reports use: `*build/reports/tests/` pattern.
       is_required: true
-  - result_path_pattern: "*build/test-results/"
+  - result_path_pattern: "*build/test-results"
     opts:
       category: Options
       title: Local unit test XML result directory pattern

--- a/step.yml
+++ b/step.yml
@@ -67,14 +67,14 @@ inputs:
 
         - `<path_to_your_project>/app/build/reports/tests/testDebugUnitTest`
 
-        this case use: `*build/reports/tests/testDebugUnitTest/` pattern.
+        this case use: `*build/reports/tests/testDebugUnitTest` pattern.
 
         Example 2: app module and NO variant is selected and the HTML reports are generated at:
 
         - `<path_to_your_project>/app/build/reports/tests/testDebugUnitTest`
         - `<path_to_your_project>/app/build/reports/tests/testReleaseUnitTest`
 
-        to export every variant's reports use: `*build/reports/tests/` pattern.
+        to export every variant's reports use: `*build/reports/tests` pattern.
       is_required: true
   - result_path_pattern: "*build/test-results"
     opts:
@@ -90,14 +90,14 @@ inputs:
 
         - `<path_to_your_project>/app/build/test-results/testDebugUnitTest`
 
-        this case use: `*build/test-results/testDebugUnitTest/` pattern.
+        this case use: `*build/test-results/testDebugUnitTest` pattern.
 
         Example 2: app module and NO variant is selected and the XML reports are generated at:
 
         - `<path_to_your_project>/app/build/test-results/testDebugUnitTest`
         - `<path_to_your_project>/app/build/test-results/testReleaseUnitTest`
 
-        to export every variant's reports use: `*build/test-results/` pattern.
+        to export every variant's reports use: `*build/test-results` pattern.
       is_required: true
   - cache_level: "only_deps"
     opts:

--- a/step.yml
+++ b/step.yml
@@ -53,19 +53,51 @@ inputs:
       summary: Extra arguments passed to the gradle task
       description: Extra arguments passed to the gradle task
       is_required: false
-  - report_path_pattern: "*build/reports"
+  - report_path_pattern: "*build/reports/tests/"
     opts:
       category: Options
-      title: Report location pattern
-      summary: Will find the report dir with the given pattern.
-      description: Will find the report dir with the given pattern.
+      title: Local unit test HTML result directory pattern
+      description: |-
+        The step will use this pattern to export __Local unit test HTML results__.
+
+        You need to override this input if you have custom output dir set for Local unit test HTML results.  
+        The pattern needs to be relative to the selected module's directory.
+
+        Example 1: app module and debug variant is selected and the HTML report is generated at:
+
+        - `<path_to_your_project>/app/build/reports/tests/testDebugUnitTest`
+
+        this case use: `*build/reports/tests/testDebugUnitTest/` pattern.
+
+        Example 2: app module and NO variant is selected and the HTML reports are generated at:
+
+        - `<path_to_your_project>/app/build/reports/tests/testDebugUnitTest`
+        - `<path_to_your_project>/app/build/reports/tests/testReleaseUnitTest`
+
+        to export every variant's reports use: `*build/reports/tests/` pattern.
       is_required: true
-  - result_path_pattern: "*build/test-results"
+  - result_path_pattern: "*build/test-results/"
     opts:
       category: Options
-      title: Test results location pattern
-      summary: Will find the test-results dir with the given pattern.
-      description: Will find test-results dir with the given pattern.
+      title: Local unit test XML result directory pattern
+      description: |-
+        The step will use this pattern to export __Local unit test XML results__.
+
+        You need to override this input if you have custom output dir set for Local unit test XML results.  
+        The pattern needs to be relative to the selected module's directory.
+
+        Example 1: app module and debug variant is selected and the XML report is generated at:
+
+        - `<path_to_your_project>/app/build/test-results/testDebugUnitTest`
+
+        this case use: `*build/test-results/testDebugUnitTest/` pattern.
+
+        Example 2: app module and NO variant is selected and the XML reports are generated at:
+
+        - `<path_to_your_project>/app/build/test-results/testDebugUnitTest`
+        - `<path_to_your_project>/app/build/test-results/testReleaseUnitTest`
+
+        to export every variant's reports use: `*build/test-results/` pattern.
       is_required: true
   - cache_level: "only_deps"
     opts:

--- a/step.yml
+++ b/step.yml
@@ -58,7 +58,8 @@ inputs:
       category: Options
       title: Local unit test HTML result directory pattern
       description: |-
-        The step will use this pattern to export __Local unit test HTML results__.
+        The step will use this pattern to export __Local unit test HTML results__.  
+        The whole HTML results directory will be zipped and moved to the `$BITRISE_DEPLOY_DIR`.
 
         You need to override this input if you have custom output dir set for Local unit test HTML results.  
         The pattern needs to be relative to the selected module's directory.
@@ -81,7 +82,9 @@ inputs:
       category: Options
       title: Local unit test XML result directory pattern
       description: |-
-        The step will use this pattern to export __Local unit test XML results__.
+        The step will use this pattern to export __Local unit test XML results__.  
+        The whole XML results directory will be zipped and moved to the `$BITRISE_DEPLOY_DIR`  
+        and the result files will be deployed to the Ship Addon.
 
         You need to override this input if you have custom output dir set for Local unit test XML results.  
         The pattern needs to be relative to the selected module's directory.

--- a/testaddon.go
+++ b/testaddon.go
@@ -8,9 +8,9 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-// getUniqueDir returns the unique subdirectory inside the test addon export diroctory for a given artifact.
-func getUniqueDir(path string) (string, error) {
-	log.Debugf("getUniqueDir(%s)", path)
+// getVariantDir returns the unique subdirectory inside the test addon export diroctory for a given artifact.
+func getVariantDir(path string) (string, error) {
+	log.Debugf("getVariantDir(%s)", path)
 	parts := strings.Split(path, "/")
 	i := len(parts) - 1
 	for i > 0 && parts[i] != "test-results" {
@@ -43,6 +43,6 @@ func getUniqueDir(path string) (string, error) {
 	module := parts[i-2]
 	ret := module + "-" + variant
 
-	log.Debugf("getUniqueDir(%s): (%s,%v)", path, ret, nil)
+	log.Debugf("getVariantDir(%s): (%s,%v)", path, ret, nil)
 	return ret, nil
 }

--- a/testaddon.go
+++ b/testaddon.go
@@ -8,6 +8,15 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
+func getExportDir(artifactPath string) string {
+	dir, err := getVariantDir(artifactPath)
+	if err != nil {
+		return "other"
+	}
+	
+	return dir
+}
+
 // getVariantDir returns the unique subdirectory inside the test addon export diroctory for a given artifact.
 func getVariantDir(path string) (string, error) {
 	log.Debugf("getVariantDir(%s)", path)

--- a/testaddon.go
+++ b/testaddon.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
-
-	"github.com/bitrise-io/go-utils/log"
 )
+
+// OtherDirName is a directory name of non Android Unit test results
+const OtherDirName = "other"
 
 func getExportDir(artifactPath string) string {
 	dir, err := getVariantDir(artifactPath)
 	if err != nil {
-		return "other"
+		return OtherDirName
 	}
 
 	return dir
@@ -19,7 +20,6 @@ func getExportDir(artifactPath string) string {
 
 // getVariantDir returns the unique subdirectory inside the test addon export directory for a given artifact.
 func getVariantDir(path string) (string, error) {
-	log.Debugf("getVariantDir(%s)", path)
 	parts := strings.Split(path, "/")
 	i := len(parts) - 1
 	for i > 0 && parts[i] != "test-results" {
@@ -52,6 +52,5 @@ func getVariantDir(path string) (string, error) {
 	module := parts[i-2]
 	ret := module + "-" + variant
 
-	log.Debugf("getVariantDir(%s): (%s,%v)", path, ret, nil)
 	return ret, nil
 }

--- a/testaddon.go
+++ b/testaddon.go
@@ -13,11 +13,11 @@ func getExportDir(artifactPath string) string {
 	if err != nil {
 		return "other"
 	}
-	
+
 	return dir
 }
 
-// getVariantDir returns the unique subdirectory inside the test addon export diroctory for a given artifact.
+// getVariantDir returns the unique subdirectory inside the test addon export directory for a given artifact.
 func getVariantDir(path string) (string, error) {
 	log.Debugf("getVariantDir(%s)", path)
 	parts := strings.Split(path, "/")

--- a/testaddon_test.go
+++ b/testaddon_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestGetUniqueDir(t *testing.T) {
+func TestGetVariantDir(t *testing.T) {
 	tc := []struct{
 		title string
 		path string
@@ -26,7 +26,7 @@ func TestGetUniqueDir(t *testing.T) {
 	}
 	
 	for _, tt := range tc {
-		str, err := getUniqueDir(tt.path)
+		str, err := getVariantDir(tt.path)
 		if str != tt.wantStr || (err != nil) != tt.isErr {
 			t.Fatalf("%s: got (%s, %s)", tt.title, str, err)
 		}

--- a/testaddon_test.go
+++ b/testaddon_test.go
@@ -33,3 +33,28 @@ func TestGetVariantDir(t *testing.T) {
 	}
 
 }
+
+func TestGetExportDir(t *testing.T) {
+	tc := []struct{
+		title string
+		artifactPath string
+		want string
+	}{
+		{
+			title: "should return 'other' for non mappable result path",
+			artifactPath: "/path/to/non-android/result.xml",
+			want: "other",
+		},
+		{
+			title: "should return string in <module>-<variant> for android result path",
+			artifactPath: "/path/to/app/module/test-results/testDemoDebugUnitTest/result.xml",
+			want: "app-demoDebug",
+		},
+	}
+
+	for _, tt := range tc {
+		if got := getExportDir(tt.artifactPath); got != tt.want {
+			t.Fatalf("%s: got '%s' want '%s'", tt.title, got, tt.want)
+		}
+	}
+}

--- a/testaddon_test.go
+++ b/testaddon_test.go
@@ -5,26 +5,38 @@ import (
 )
 
 func TestGetVariantDir(t *testing.T) {
-	tc := []struct{
-		title string
-		path string
+	tc := []struct {
+		title   string
+		path    string
 		wantStr string
-		isErr bool
+		isErr   bool
 	}{
 		{
-			title: "should return error on empty string",
-			path: "",
-			wantStr: "",
-			isErr: true, 
+			title:   "should return variant dir",
+			path:    "./app/build/test-results/testDebugUnitTest/TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml",
+			wantStr: "app-debug",
+			isErr:   false,
 		},
 		{
-			title: "should return error if artifact path ends in test results folder with trailing slash",
-			path: "/path/to/test-results/",
+			title:   "should return error on empty string",
+			path:    "",
 			wantStr: "",
-			isErr: true, 
+			isErr:   true,
+		},
+		{
+			title:   "should return error for non default Local Android Unit result XML path",
+			path:    "/path/to/test-results/",
+			wantStr: "",
+			isErr:   true,
+		},
+		{
+			title:   "should return error for non default Local Android Unit result XML path",
+			path:    "./app/build/test-results/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml",
+			wantStr: "",
+			isErr:   true,
 		},
 	}
-	
+
 	for _, tt := range tc {
 		str, err := getVariantDir(tt.path)
 		if str != tt.wantStr || (err != nil) != tt.isErr {
@@ -35,20 +47,20 @@ func TestGetVariantDir(t *testing.T) {
 }
 
 func TestGetExportDir(t *testing.T) {
-	tc := []struct{
-		title string
+	tc := []struct {
+		title        string
 		artifactPath string
-		want string
+		want         string
 	}{
 		{
-			title: "should return 'other' for non mappable result path",
-			artifactPath: "/path/to/non-android/result.xml",
-			want: "other",
+			title:        "should return 'other' for non mappable result path",
+			artifactPath: "./app/build/test-results/jacocoTestReleaseUnitTestReport/jacocoTestReleaseUnitTestReport.xml",
+			want:         "other",
 		},
 		{
-			title: "should return string in <module>-<variant> for android result path",
-			artifactPath: "/path/to/app/module/test-results/testDemoDebugUnitTest/result.xml",
-			want: "app-demoDebug",
+			title:        "should return string in <module>-<variant> for android result path",
+			artifactPath: "./app/build/test-results/testDemoDebugUnitTest/TEST-sample.results.test.multiple.bitrise.com.multipletestresultssample.UnitTest0.xml",
+			want:         "app-demoDebug",
 		},
 	}
 


### PR DESCRIPTION
Non Android related results were simply skipped during the export process. This PR introduces a fix for this.

Paths that are not recognized as Android test results are now exported to an 'other' folder.

---

- __breaking change__: previous version used `<project_dir>/<module>/*TEST*.xml` pattern to export reports for the testing addon, however it was totally incorrect. `report_path_pattern` and `result_path_pattern` inputs should control what we determin as test result. This misunderstanding caused the rest of the original issue.
- __breaking change__: default value for `report_path_pattern` updated based on: https://developer.android.com/studio/test/command-line
- typo fixes
- clarification for step inputs `report_path_pattern` and `result_path_pattern` based on: https://developer.android.com/studio/test/command-line
- log improvements