### PR TITLE
Tool 958 common android cache implementation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4490bcf821454642055ce07c60088276229717012434863fd172f31268eb6803"
+  digest = "1:6f561a11e048a6b3e76fd7c89288e6b078f299afcd2d38e0f9616807ec541fb2"
   name = "github.com/bitrise-io/go-android"
-  packages = ["gradle"]
+  packages = [
+    "cache",
+    "gradle",
+  ]
   pruneopts = "UT"
-  revision = "8082fe069ed29f394c2fd0724dd6bdc64e5cf6b4"
+  revision = "a28433b493561a6575fcec699f93f124d22150d1"
 
 [[projects]]
   branch = "master"
@@ -60,6 +63,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/bitrise-io/go-android/cache",
     "github.com/bitrise-io/go-android/gradle",
     "github.com/bitrise-io/go-steputils/cache",
     "github.com/bitrise-io/go-steputils/stepconf",

--- a/main.go
+++ b/main.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bitrise-io/go-android/cache"
 	"github.com/bitrise-io/go-android/gradle"
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/sliceutil"
-	"github.com/bitrise-io/go-android/cache"
 	"github.com/bitrise-steplib/bitrise-step-android-unit-test/testaddon"
 	shellquote "github.com/kballard/go-shellquote"
 )

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/sliceutil"
-	"github.com/bitrise-steplib/bitrise-step-android-unit-test/cache"
+	"github.com/bitrise-io/go-android/cache"
 	"github.com/bitrise-steplib/bitrise-step-android-unit-test/testaddon"
 	shellquote "github.com/kballard/go-shellquote"
 )

--- a/testaddon/testaddon.go
+++ b/testaddon/testaddon.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// ResultDescriptorFileName is the name of the test result descriptor file.
-	ResultDescriptorFileName  = "test-info.json"
+	ResultDescriptorFileName = "test-info.json"
 )
 
 func generateTestInfoFile(dir string, data []byte) error {
@@ -38,26 +38,26 @@ func generateTestInfoFile(dir string, data []byte) error {
 // ExportArtifact exports artifact found at path in directory uniqueDir,
 // rooted at baseDir.
 func ExportArtifact(path, baseDir, uniqueDir string) error {
-		exportDir := filepath.Join(baseDir, uniqueDir)
+	exportDir := filepath.Join(baseDir, uniqueDir)
 
-		if err := os.MkdirAll(exportDir, os.ModePerm); err != nil {
-			return fmt.Errorf("skipping artifact (%s): could not ensure unique export dir (%s): %s", path, exportDir, err)
-		}
+	if err := os.MkdirAll(exportDir, os.ModePerm); err != nil {
+		return fmt.Errorf("skipping artifact (%s): could not ensure unique export dir (%s): %s", path, exportDir, err)
+	}
 
-		if _, err := os.Stat(filepath.Join(exportDir, ResultDescriptorFileName)); os.IsNotExist(err) {
-			m := map[string]string{"test-name": uniqueDir}
-			data, err := json.Marshal(m)
-			if err != nil {
-				return fmt.Errorf("create test info descriptor: json marshal data (%s): %s", m, err)
-			}
-			if err := generateTestInfoFile(exportDir, data); err != nil {
-				return fmt.Errorf("create test info descriptor: generate file: %s", err)
-			}
+	if _, err := os.Stat(filepath.Join(exportDir, ResultDescriptorFileName)); os.IsNotExist(err) {
+		m := map[string]string{"test-name": uniqueDir}
+		data, err := json.Marshal(m)
+		if err != nil {
+			return fmt.Errorf("create test info descriptor: json marshal data (%s): %s", m, err)
 		}
+		if err := generateTestInfoFile(exportDir, data); err != nil {
+			return fmt.Errorf("create test info descriptor: generate file: %s", err)
+		}
+	}
 
-		name := filepath.Base(path)
-		if err := command.CopyFile(path, filepath.Join(exportDir, name)); err != nil {
-			return fmt.Errorf("failed to export artifact (%s), error: %v", name, err)
-		}
+	name := filepath.Base(path)
+	if err := command.CopyFile(path, filepath.Join(exportDir, name)); err != nil {
+		return fmt.Errorf("failed to export artifact (%s), error: %v", name, err)
+	}
 	return nil
 }

--- a/vendor/github.com/bitrise-io/go-android/cache/cache.go
+++ b/vendor/github.com/bitrise-io/go-android/cache/cache.go
@@ -1,0 +1,132 @@
+package cache
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/go-steputils/cache"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/pathutil"
+)
+
+// Level defines the extent to which caching should be used.
+// - LevelNone: no caching
+// - LevelDeps: only dependencies will be cached
+// - LevelAll: caching will include gradle and android build cache
+type Level string
+
+// Cache level
+const (
+	LevelNone = Level("none")
+	LevelDeps = Level("only_deps")
+	LevelAll  = Level("all")
+)
+
+// Collect walks the directory tree underneath projectRoot and registers matching
+// paths for caching based on the value of cacheLevel. Returns an error if there
+// was an underlying error that would lead to a corrupted cache file, otherwise
+// the given path is skipped.
+func Collect(projectRoot string, cacheLevel Level) error {
+	if cacheLevel != LevelNone {
+		gradleCache := cache.New()
+		homeDir := pathutil.UserHomeDir()
+
+		projectRoot, err := filepath.Abs(projectRoot)
+		if err != nil {
+			return fmt.Errorf("cache collection skipped: failed to determine project root path")
+		}
+
+		lockFilePath := filepath.Join(projectRoot, "gradle.deps")
+
+		excludePths := []string{
+			"~/.gradle/**",
+			"~/.android/build-cache/**",
+			"*.lock",
+			"*.bin",
+			"*/build/*.json",
+			"*/build/*.html",
+			"*/build/*.xml",
+			"*/build/*.properties",
+			"*/build/*/zip-cache/*",
+			"*.log",
+			"*.txt",
+			"*.rawproto",
+			"!*.ap_",
+			"!*.apk",
+		}
+
+		var includePths []string
+
+		if cacheLevel == LevelAll || cacheLevel == LevelDeps {
+			lockfileContent := ""
+			if err := filepath.Walk(projectRoot, func(path string, f os.FileInfo, err error) error {
+				if !f.IsDir() && strings.HasSuffix(f.Name(), ".gradle") && !strings.Contains(path, "node_modules") {
+					if md5Hash, err := computeMD5String(path); err != nil {
+						log.Warnf("Failed to compute MD5 hash of file(%s), error: %s", path, err)
+					} else {
+						lockfileContent += md5Hash
+					}
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("dependency map generation skipped: failed to collect dependencies")
+			}
+			if err := fileutil.WriteStringToFile(lockFilePath, lockfileContent); err != nil {
+				return fmt.Errorf("dependency map generation skipped: failed to write lockfile, error: %s", err)
+			}
+
+			includePths = append(includePths, fmt.Sprintf("%s -> %s", filepath.Join(homeDir, ".gradle"), lockFilePath))
+			includePths = append(includePths, fmt.Sprintf("%s -> %s", filepath.Join(homeDir, ".kotlin"), lockFilePath))
+			includePths = append(includePths, fmt.Sprintf("%s -> %s", filepath.Join(homeDir, ".m2"), lockFilePath))
+		}
+
+		if cacheLevel == LevelAll {
+			includePths = append(includePths, fmt.Sprintf("%s -> %s", filepath.Join(homeDir, ".android", "build-cache"), lockFilePath))
+
+			if err := filepath.Walk(projectRoot, func(path string, f os.FileInfo, err error) error {
+				if f.IsDir() {
+					if f.Name() == "build" {
+						includePths = append(includePths, path)
+					}
+					if f.Name() == ".gradle" {
+						includePths = append(includePths, path)
+					}
+				}
+				return nil
+			}); err != nil {
+				return fmt.Errorf("cache collection skipped: failed to determine cache paths")
+			}
+		}
+		gradleCache.IncludePath(strings.Join(includePths, "\n"))
+		gradleCache.ExcludePath(strings.Join(excludePths, "\n"))
+
+		if err := gradleCache.Commit(); err != nil {
+			return fmt.Errorf("cache collection skipped: failed to commit cache paths")
+		}
+	}
+	return nil
+}
+
+func computeMD5String(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("Failed to close file(%s), error: %s", filePath, err)
+		}
+	}()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/vendor/github.com/bitrise-io/go-android/gradle/task.go
+++ b/vendor/github.com/bitrise-io/go-android/gradle/task.go
@@ -44,9 +44,10 @@ lines:
 		var module string
 
 		split := strings.Split(l, ":")
-		if len(split) > 1 {
-			module = split[0]
-			l = split[1]
+		size := len(split)
+		if size > 1 {
+			module = strings.Join(split[:size - 1], ":")
+			l = split[size - 1]
 		}
 		// module removed if any
 		if strings.HasPrefix(l, task.name) {


### PR DESCRIPTION
wiring in the recently centralized cache logic from go-android repository

the logic was extracted from this very repository itself, thus, only the import path has changed