### PR TITLE
fix: resolve gradlew to absolute path so Dir+relative-path doesn't double up

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,7 +146,14 @@ func runStep(logger log.Logger) error {
 	// Inline of testTask.GetCommand(filteredVariants, args...) so the gradlew
 	// path and argv are explicit — needed to route the invocation through
 	// `bitrise-build-cache react-native run -- ...` when RN cache is active.
-	gradlewPath := filepath.Join(config.ProjectLocation, "gradlew")
+	// Resolve gradlew to an absolute path: the command also sets Dir to the
+	// project location, and a relative gradlew name (e.g. "_tmp/gradlew")
+	// gets re-resolved relative to that Dir at exec time, producing
+	// "_tmp/_tmp/gradlew" and an ENOENT.
+	gradlewPath, err := filepath.Abs(filepath.Join(config.ProjectLocation, "gradlew"))
+	if err != nil {
+		return fmt.Errorf("resolve gradlew path: %v", err)
+	}
 	var taskNames []string
 	for module, variants := range filteredVariants {
 		modulePrefix := ""


### PR DESCRIPTION
## Summary

The wrap PR (#45) built the gradlew exec name as `filepath.Join(config.ProjectLocation, "gradlew")` — e.g. `_tmp/gradlew` — and passed that to `cmdFactory.Create` while also setting `command.Opts.Dir: config.ProjectLocation`. `exec` chdirs to `Dir` first and then resolves the relative name from there, so the child tries to exec `_tmp/_tmp/gradlew` and fails with ENOENT:

```
Run test task failed: fork/exec _tmp/gradlew: no such file or directory
```

This fires whenever `project_location` is a relative path (default in most workflows; e.g. `./_tmp` in the step's own e2e fixture).

## Fix

Resolve gradlew via `filepath.Abs` so the exec name stays valid regardless of `Dir`. The wrap helper still rewrites argv when RN cache is active and passes through unchanged otherwise.

## Verified

- `go build ./... && go test ./...` clean.
- Same pattern + fix applied to the sibling wrap PR in [bitrise-step-android-build-for-ui-testing#28](https://github.com/bitrise-steplib/bitrise-step-android-build-for-ui-testing/pull/28). A parallel fix is incoming for [bitrise-step-android-lint#34](https://github.com/bitrise-steplib/bitrise-step-android-lint/pull/34), which uses the same pattern.
- `bitrise-step-android-build` (the reference impl) already uses `filepath.Abs` before joining "gradlew" — not affected. `steps-gradle-unit-test` and `steps-gradle-runner` use different patterns that also avoid the trap.

Follow-up to the RN wrap helper rollout under ACI-4307.